### PR TITLE
remove and includes pkgs for appearance

### DIFF
--- a/usr/share/bigbashview/bcc/apps/bigbashview-calamares/desktops/bspwm/pkginstall.txt
+++ b/usr/share/bigbashview/bcc/apps/bigbashview-calamares/desktops/bspwm/pkginstall.txt
@@ -33,7 +33,6 @@ xfce4-terminal
 zathura
 brightnessctl
 polybar
-lxappearance
 nitrogen
 arandr
 htop
@@ -42,7 +41,6 @@ xcolor
 betterlockscreen
 catppuccin-cursors-mocha
 catppuccin-gtk-theme-mocha
-catppuccin-wallpapers-git
 papirus-folders-catppuccin-git
 ttf-icomoon-feather
 ksuperkey
@@ -55,3 +53,6 @@ lightdm-slick-biglinux-greeter
 lightdm-gtk-greeter
 lightdm-webkit2-greeter
 gdu
+ttf-iosevka-nerd
+xorg-xinput
+xsettingsd


### PR DESCRIPTION
Remove pkgs: catppuccin-wallpapers and lxappearance. 

Include pkgs: ttf-iosevka-nerd (font), xorg-xinput (for touchpad settings), xsettingsd (improve themes and fonts settings)